### PR TITLE
Memo 4303 feilmeldinger

### DIFF
--- a/docs/documentation/api/index.md
+++ b/docs/documentation/api/index.md
@@ -318,3 +318,127 @@ HEADERS:
 ```
 
 Innsendingen vil nå kunne finnes i altinns meldings-arkiv.
+
+## Feilmeldinger
+
+### `POST {org}/{app}/instances`
+
+**Response 400 - Bad Request:** <br>
+Example Value
+
+```JSON
+{
+  "type": "string",
+  "title": "string",
+  "status": 0,
+  "detail": "string",
+  "instance": "string"
+}
+```
+
+**Response 403 - Forbidden:** <br>
+Example Value:
+
+```JSON
+{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.3","title":"Forbidden","status":403,"traceId":"00-44eab35cb9ca2049b24de316f380a774-a724e045b09dfc44-00"}
+```
+
+Denne feilmeldingen kan en få hvis en prøver å lage en instanse hvor innlogget bruker ikke har rettigheter til organisasjonen definert i request header.
+Dette vil da også gjelde hvis innlogget bruker ikke har tilstrekkelig roller for å opprette en instans.
+
+**Response 404 - Not Found:** <br>
+Example Value:
+
+```JSON
+"Cannot lookup party: Failed to lookup party by organisationNumber: 123456789. The exception was: 404 - Not Found - "
+```
+
+Denne feilmeldingen kan en få hvis en setter organisasjonsnummeret i request headeren til noe ugyldig.
+
+### `PUT {instansUrl}/data?dataType=mvamelding`
+
+**Response 403 - Forbidden:** <br>
+Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
+
+### `POST {instansUrl}/data/{dataId}`
+
+**Response 403 - Forbidden:** <br>
+Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
+
+### `POST {instansUrl}/data?dataType=vedlegg`
+
+**Response 403 - Forbidden:** <br>
+Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
+
+### `PUT {instansUrl}/process/next`
+
+**Response 403 - Forbidden:** <br>
+Hvis innlogget bruker prøver å bytte til neste steg i instansprossessen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
+
+**Response 409 - Conflict:** <br>
+Example Value
+
+```JSON
+{
+  "type": "string",
+  "title": "string",
+  "status": 0,
+  "detail": "string",
+  "instance": "string"
+}
+```
+
+```
+"Valideringsfeil: Organisasjonsnummeret i instansen er forskjellig fra organisasjonsnummeret i MvaMeldingInnsending (\"konvolutt\")"
+```
+
+Hvis organisasjonsnummeret som ble brukt til å lage instansen er forskjellig fra organisasjonsnummeret definert i MvaMeldingInnsend vil en få denne feilmeldingen.
+
+```
+"Valideringsfeil: Organisasjonsnummeret i MvaMeldingInnsending (\"konvolutt\") er forskjellig fra organisasjonsnummeret i {filnavn}"
+```
+
+Hvis organisasjonsnummeret som er definert i MvaMeldingInnsending er forskjellig fra organisjasnonsnummeret som er definert i mva-meldingen vil en få denne feilmeldingen.
+
+```
+"Valideringsfeil: Liste med vedlegg definert i MvaMeldingInnsending (\"konvolutt\") er forskjellig fra listen med vedlegg som er lastet opp i instansen."
+```
+
+Hvis listen over vedlegg som er definert i MvaMeldingInnsending er forskjellig fra de som har blitt lastet opp instansen vil en få denne feilmeldingen.
+
+```
+"Valideringsfeil: Meldingskategorien i MvaMeldingInnsending (\"konvolutt\") er forsjellig fra Meldingskategorien i {filnavn}"
+```
+
+Hvis verdien i meldingskategori feltet for MvaMeldingInnsending er forskjellig fra meldingskategorien i mva-meldigen vil en få denne feilmeldingen.
+
+### `GET {instansUrl}`
+
+**Response 400 - Bad Request:** <br>
+Example Value
+
+```JSON
+{
+  "type": "string",
+  "title": "string",
+  "status": 0,
+  "detail": "string",
+  "instance": "string"
+}
+```
+
+**Response 403 - Forbidden:** <br>
+Hvis innlogget bruker prøver å hente instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
+
+**Response 404 - Not Found:** <br>
+Example Value
+
+```JSON
+{
+  "type": "string",
+  "title": "string",
+  "status": 0,
+  "detail": "string",
+  "instance": "string"
+}
+```

--- a/docs/documentation/api/index.md
+++ b/docs/documentation/api/index.md
@@ -323,8 +323,8 @@ Innsendingen vil nå kunne finnes i altinns meldings-arkiv.
 
 ### `POST {org}/{app}/instances`
 
-**Response 400 - Bad Request:** <br>
-Example Value
+**Respons 400 - Bad Request:** <br>
+Eksempel verdi
 
 ```JSON
 {
@@ -336,8 +336,8 @@ Example Value
 }
 ```
 
-**Response 403 - Forbidden:** <br>
-Example Value:
+**Respons 403 - Forbidden:** <br>
+Eksempel verdi
 
 ```JSON
 {"type":"https://tools.ietf.org/html/rfc7231#section-6.5.3","title":"Forbidden","status":403,"traceId":"00-44eab35cb9ca2049b24de316f380a774-a724e045b09dfc44-00"}
@@ -346,8 +346,8 @@ Example Value:
 Denne feilmeldingen kan en få hvis en prøver å lage en instanse hvor innlogget bruker ikke har rettigheter til organisasjonen definert i request header.
 Dette vil da også gjelde hvis innlogget bruker ikke har tilstrekkelig roller for å opprette en instans.
 
-**Response 404 - Not Found:** <br>
-Example Value:
+**Respons 404 - Not Found:** <br>
+Eksempel verdi
 
 ```JSON
 "Cannot lookup party: Failed to lookup party by organisationNumber: 123456789. The exception was: 404 - Not Found - "
@@ -355,28 +355,28 @@ Example Value:
 
 Denne feilmeldingen kan en få hvis en setter organisasjonsnummeret i request headeren til noe ugyldig.
 
-### `PUT {instansUrl}/data?dataType=mvamelding`
+### `PUT {instansUrl}/data/{dataId}`
 
-**Response 403 - Forbidden:** <br>
+**Respons 403 - Forbidden:** <br>
 Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
 
-### `POST {instansUrl}/data/{dataId}`
+### `POST {instansUrl}/data?dataType=mvamelding`
 
-**Response 403 - Forbidden:** <br>
+**Respons 403 - Forbidden:** <br>
 Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
 
 ### `POST {instansUrl}/data?dataType=vedlegg`
 
-**Response 403 - Forbidden:** <br>
+**Respons 403 - Forbidden:** <br>
 Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
 
 ### `PUT {instansUrl}/process/next`
 
-**Response 403 - Forbidden:** <br>
+**Respons 403 - Forbidden:** <br>
 Hvis innlogget bruker prøver å bytte til neste steg i instansprossessen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
 
-**Response 409 - Conflict:** <br>
-Example Value
+**Respons 409 - Conflict:** <br>
+Eksempel verdi
 
 ```JSON
 {
@@ -392,7 +392,7 @@ Example Value
 "Valideringsfeil: Organisasjonsnummeret i instansen er forskjellig fra organisasjonsnummeret i MvaMeldingInnsending (\"konvolutt\")"
 ```
 
-Hvis organisasjonsnummeret som ble brukt til å lage instansen er forskjellig fra organisasjonsnummeret definert i MvaMeldingInnsend vil en få denne feilmeldingen.
+Hvis organisasjonsnummeret som ble brukt til å lage instansen er forskjellig fra organisasjonsnummeret definert i MvaMeldingInnsending vil en få denne feilmeldingen.
 
 ```
 "Valideringsfeil: Organisasjonsnummeret i MvaMeldingInnsending (\"konvolutt\") er forskjellig fra organisasjonsnummeret i {filnavn}"
@@ -414,8 +414,8 @@ Hvis verdien i meldingskategori feltet for MvaMeldingInnsending er forskjellig f
 
 ### `GET {instansUrl}`
 
-**Response 400 - Bad Request:** <br>
-Example Value
+**Respons 400 - Bad Request:** <br>
+Eksempel verdi
 
 ```JSON
 {
@@ -427,11 +427,11 @@ Example Value
 }
 ```
 
-**Response 403 - Forbidden:** <br>
+**Respons 403 - Forbidden:** <br>
 Hvis innlogget bruker prøver å hente instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
 
-**Response 404 - Not Found:** <br>
-Example Value
+**Respons 404 - Not Found:** <br>
+Eksempel verdi
 
 ```JSON
 {

--- a/docs/documentation/api/index.md
+++ b/docs/documentation/api/index.md
@@ -197,6 +197,40 @@ Resten av kallene i sekvensen for innsendingen benytter `instansUrl`. Denne kan 
 
 Eksempel på instansUrl: `https://skd.apps.tt02.altinn.no/skd/mva-melding-innsending-etm2/instances/3949387/abba061g-3abb-4bab-bab8-c9abbaf1ed50/data/28abba46-dea8-4ab7-ba90-433abba906df`
 
+**Feilmeldinger**
+
+_Respons 400 - Bad Request:_ <br>
+Eksempel verdi
+
+```JSON
+{
+  "type": "string",
+  "title": "string",
+  "status": 0,
+  "detail": "string",
+  "instance": "string"
+}
+```
+
+_Respons 403 - Forbidden:_ <br>
+Eksempel verdi
+
+```JSON
+{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.3","title":"Forbidden","status":403,"traceId":"00-44eab35cb9ca2049b24de316f380a774-a724e045b09dfc44-00"}
+```
+
+Denne feilmeldingen kan en få hvis en prøver å lage en instanse hvor innlogget bruker ikke har rettigheter til organisasjonen definert i request header.
+Dette vil da også gjelde hvis innlogget bruker ikke har tilstrekkelig roller for å opprette en instans.
+
+_Respons 404 - Not Found:_ <br>
+Eksempel verdi
+
+```JSON
+"Cannot lookup party: Failed to lookup party by organisationNumber: 123456789. The exception was: 404 - Not Found - "
+```
+
+Denne feilmeldingen kan en få hvis en setter organisasjonsnummeret i request headeren til noe ugyldig.
+
 ### Last Opp MvaMeldingInnsending
 
 MvaMeldingInnsending er en datatype for metadata for innsendingen. Objektet man skal fylle ut blir skapt under instansieringen og vil kunne finnes i instans-objektets `data`-liste og har `"dataType": "no.skatteetaten.fastsetting.avgift.mva.mvameldinginnsending.v0.1"`. Siden dette objektet allerede finnes når man skal laste opp MvaMeldingInnsending, benyttes PUT for å oppdatere data-elementet.
@@ -239,6 +273,11 @@ Content:
 
 Eksempel på xml-fil for mvaMeldingInnsending finnes under <a href="https://skatteetaten.github.io/mva-meldingen/documentation/test/" target="_blank">Test</a>.
 
+**Feilmeldinger**
+
+_Respons 403 - Forbidden:_ <br>
+Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
+
 ### Last Opp MvaMelding
 
 Modellen for <a href="../informasjonsmodell/xsd/no.skatteetaten.fastsetting.avgift.mva.skattemeldingformerverdiavgift.v0.9.xsd" target="_blank">no.skatteetaten.fastsetting.avgift.mva.skattemeldingformerverdiavgift.v0.9.xsd</a>
@@ -268,6 +307,11 @@ Content:
 ```
 
 Dette kallet vil laste opp xml-dokumentet til instansen.
+
+**Feilmeldinger**
+
+_Respons 403 - Forbidden:_ <br>
+Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
 
 ### Last Opp Vedlegg
 
@@ -304,6 +348,11 @@ Dette kallet vil laste opp pdf-dokumentet til instansen.
 
 Husk at `content-type` skal være passende for vedlegget som skal lastes opp og at filnavnet i `Content-Disposition`- headeren også bør være passende og unikt. Det er dette filnavnet Skatteetaten vil forholde seg til for vedlegget.
 
+**Feilmeldinger**
+
+_Respons 403 - Forbidden:_ <br>
+Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
+
 ### Send Inn Mva Melding Innsending
 
 Dette steget bruker prosess-apiet til instansen og instansen vil avslutte utfyllingssteget for Mva Melding Innsending og til neste steg i applikasjonens prosess for instansen. Foreløpig er det kun ett steg i applikasjonens prosess, så i skrivende stund vil dette kallet fullføre innsendingen.
@@ -319,63 +368,12 @@ HEADERS:
 
 Innsendingen vil nå kunne finnes i altinns meldings-arkiv.
 
-## Feilmeldinger
+**Feilmeldinger**
 
-### `POST {org}/{app}/instances`
-
-**Respons 400 - Bad Request:** <br>
-Eksempel verdi
-
-```JSON
-{
-  "type": "string",
-  "title": "string",
-  "status": 0,
-  "detail": "string",
-  "instance": "string"
-}
-```
-
-**Respons 403 - Forbidden:** <br>
-Eksempel verdi
-
-```JSON
-{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.3","title":"Forbidden","status":403,"traceId":"00-44eab35cb9ca2049b24de316f380a774-a724e045b09dfc44-00"}
-```
-
-Denne feilmeldingen kan en få hvis en prøver å lage en instanse hvor innlogget bruker ikke har rettigheter til organisasjonen definert i request header.
-Dette vil da også gjelde hvis innlogget bruker ikke har tilstrekkelig roller for å opprette en instans.
-
-**Respons 404 - Not Found:** <br>
-Eksempel verdi
-
-```JSON
-"Cannot lookup party: Failed to lookup party by organisationNumber: 123456789. The exception was: 404 - Not Found - "
-```
-
-Denne feilmeldingen kan en få hvis en setter organisasjonsnummeret i request headeren til noe ugyldig.
-
-### `PUT {instansUrl}/data/{dataId}`
-
-**Respons 403 - Forbidden:** <br>
-Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
-
-### `POST {instansUrl}/data?dataType=mvamelding`
-
-**Respons 403 - Forbidden:** <br>
-Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
-
-### `POST {instansUrl}/data?dataType=vedlegg`
-
-**Respons 403 - Forbidden:** <br>
-Hvis innlogget bruker prøver å laste opp fil til instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
-
-### `PUT {instansUrl}/process/next`
-
-**Respons 403 - Forbidden:** <br>
+_Respons 403 - Forbidden:_ <br>
 Hvis innlogget bruker prøver å bytte til neste steg i instansprossessen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
 
-**Respons 409 - Conflict:** <br>
+_Respons 409 - Conflict:_ <br>
 Eksempel verdi
 
 ```JSON
@@ -412,9 +410,11 @@ Hvis listen over vedlegg som er definert i MvaMeldingInnsending er forskjellig f
 
 Hvis verdien i meldingskategori feltet for MvaMeldingInnsending er forskjellig fra meldingskategorien i mva-meldigen vil en få denne feilmeldingen.
 
-### `GET {instansUrl}`
+### Hent instansen
 
-**Respons 400 - Bad Request:** <br>
+**Feilmeldinger**
+
+_Respons 400 - Bad Request:_ <br>
 Eksempel verdi
 
 ```JSON
@@ -427,10 +427,10 @@ Eksempel verdi
 }
 ```
 
-**Respons 403 - Forbidden:** <br>
+_Respons 403 - Forbidden:_ <br>
 Hvis innlogget bruker prøver å hente instansen, men personen har ikke riktig roller vil en få response kode 403 tilbake.
 
-**Respons 404 - Not Found:** <br>
+_Respons 404 - Not Found:_ <br>
 Eksempel verdi
 
 ```JSON

--- a/docs/english/api/index.md
+++ b/docs/english/api/index.md
@@ -366,3 +366,127 @@ PUT {instanceUrl}/process/next
 ```
 
 The filing is now complete and can be found in Altinn's message archive.
+
+## Error messages
+
+### `POST {org}/{app}/instances`
+
+**Response 400 - Bad Request:** <br>
+Example Value
+
+```JSON
+{
+  "type": "string",
+  "title": "string",
+  "status": 0,
+  "detail": "string",
+  "instance": "string"
+}
+```
+
+**Response 403 - Forbidden:** <br>
+Example Value:
+
+```JSON
+{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.3","title":"Forbidden","status":403,"traceId":"00-44eab35cb9ca2049b24de316f380a774-a724e045b09dfc44-00"}
+```
+
+This error message could occur if you try to create an instance where the logged-in user does not have the necessary rights to the organisation number defined in the request header.
+This can also occur if the user does not have the correct roles necessary for creating an instance.
+
+**Response 404 - Not Found:** <br>
+Example Value:
+
+```JSON
+"Cannot lookup party: Failed to lookup party by organisationNumber: 123456789. The exception was: 404 - Not Found - "
+```
+
+This error message can occur when you set an invalid organisation number in the request header.
+
+### `PUT {instansUrl}/data/{dataId}`
+
+**Response 403 - Forbidden:** <br>
+If the logged-in user attempt to upload a file to the instance, but the person does not have the correct roles, you will get the response code 403 in return.
+
+### `POST {instansUrl}/data?dataType=mvamelding`
+
+**Response 403 - Forbidden:** <br>
+If the logged-in user attempt to upload a file to the instance, but the person does not have the correct roles, you will get the response code 403 in return.
+
+### `POST {instansUrl}/data?dataType=vedlegg`
+
+**Response 403 - Forbidden:** <br>
+If the logged-in user attempt to upload a file to the instance, but the person does not have the correct roles, you will get the response code 403 in return.
+
+### `PUT {instansUrl}/process/next`
+
+**Response 403 - Forbidden:** <br>
+If the logged-in user attempt to update to the next task in the instance process, but does not have the correct roles, you will get the response code 403 in return.
+
+**Response 409 - Conflict:** <br>
+Example Value
+
+```JSON
+{
+  "type": "string",
+  "title": "string",
+  "status": 0,
+  "detail": "string",
+  "instance": "string"
+}
+```
+
+```
+"Valideringsfeil: Organisasjonsnummeret i instansen er forskjellig fra organisasjonsnummeret i MvaMeldingInnsending (\"konvolutt\")"
+```
+
+You will get this error message if the organisation number used when creating the instance is different from the organisation number defined in vat-return submission.
+
+```
+"Valideringsfeil: Organisasjonsnummeret i MvaMeldingInnsending (\"konvolutt\") er forskjellig fra organisasjonsnummeret i {filnavn}"
+```
+
+You will get this error message if the organisation number defined in vat. return submission is different from the organisation number defined in vat-return.
+
+```
+"Valideringsfeil: Liste med vedlegg definert i MvaMeldingInnsending (\"konvolutt\") er forskjellig fra listen med vedlegg som er lastet opp i instansen."
+```
+
+If the list of attachments defined in at-return submission is different from the attachments uploaded to the instance, you will get this error message.
+
+```
+"Valideringsfeil: Meldingskategorien i MvaMeldingInnsending (\"konvolutt\") er forsjellig fra Meldingskategorien i {filnavn}"
+```
+
+This error message will occur if the value of the field message category in vat-return submission is different from the message category in the vat-return.
+
+### `GET {instansUrl}`
+
+**Response 400 - Bad Request:** <br>
+Example Value
+
+```JSON
+{
+  "type": "string",
+  "title": "string",
+  "status": 0,
+  "detail": "string",
+  "instance": "string"
+}
+```
+
+**Response 403 - Forbidden:** <br>
+This error message will occur if the logged-in user attempt to retrieve the instance, but the person does not have the correct roles.
+
+**Response 404 - Not Found:** <br>
+Example Value
+
+```JSON
+{
+  "type": "string",
+  "title": "string",
+  "status": 0,
+  "detail": "string",
+  "instance": "string"
+}
+```

--- a/docs/english/api/index.md
+++ b/docs/english/api/index.md
@@ -225,6 +225,40 @@ found in the `id` field in the returned instance.
 Example instanceUrl:
 `https://skd.apps.tt02.altinn.no/skd/mva-melding-innfiling-etm2/instances/3949387/abba061g-3abb-4bab-bab8-c9abbaf1ed50/data/28abba46-dea8-4ab7-ba90-433abba906df`
 
+**Error messages**
+
+_Response 400 - Bad Request:_ <br>
+Example Value
+
+```JSON
+{
+  "type": "string",
+  "title": "string",
+  "status": 0,
+  "detail": "string",
+  "instance": "string"
+}
+```
+
+_Response 403 - Forbidden:_ <br>
+Example Value:
+
+```JSON
+{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.3","title":"Forbidden","status":403,"traceId":"00-44eab35cb9ca2049b24de316f380a774-a724e045b09dfc44-00"}
+```
+
+This error message could occur if you try to create an instance where the logged-in user does not have the necessary rights to the organisation number defined in the request header.
+This can also occur if the user does not have the correct roles necessary for creating an instance.
+
+_Response 404 - Not Found:_ <br>
+Example Value:
+
+```JSON
+"Cannot lookup party: Failed to lookup party by organisationNumber: 123456789. The exception was: 404 - Not Found - "
+```
+
+This error message can occur when you set an invalid organisation number in the request header.
+
 ### Upload VAT return filing
 
 MvaMeldingInnsending is a data type for metadata for the VAT return filing.
@@ -280,12 +314,22 @@ Content:
 
 Example of xml file for VAT return filing can be found under <a href="https://skatteetaten.github.io/mva-meldingen/english/test/" target="_blank">Test</a>.
 
+**Error Messages**
+
+_Response 403 - Forbidden:_ <br>
+If the logged-in user attempt to upload a file to the instance, but the person does not have the correct roles, you will get the response code 403 in return.
+
 ### Upload VAT return
 
 The model is found here:
 <a href="../informasjonsmodell/xsd/no.skatteetaten.fastsetting.avgift.mva.skattemeldingformerverdiavgift.v0.9.xsd" target="_blank">no.skatteetaten.fastsetting.avgift.mva.skattemeldingformerverdiavgift.v0.9.xsd</a>
 
 The URL for uploading the VAT return has this structure:
+
+**Error Messages**
+
+_Response 403 - Forbidden:_ <br>
+If the logged-in user attempt to upload a file to the instance, but the person does not have the correct roles, you will get the response code 403 in return.
 
 ```
 {instanceUrl}/data?datatype=mvamelding
@@ -351,6 +395,11 @@ the attachment to be uploaded and that the file name in the
 and unique. This is the file name Skatteetaten will refer to
 for the attachment.
 
+**Error Messages**
+
+_Response 403 - Forbidden:_ <br>
+If the logged-in user attempt to upload a file to the instance, but the person does not have the correct roles, you will get the response code 403 in return.
+
 ### Submit VAT return filing
 
 This step uses the process api for the instance and the instance will go to the next step for VAT return filing in the application process. Currently, there is only
@@ -367,63 +416,12 @@ PUT {instanceUrl}/process/next
 
 The filing is now complete and can be found in Altinn's message archive.
 
-## Error messages
+**Error Messages**
 
-### `POST {org}/{app}/instances`
-
-**Response 400 - Bad Request:** <br>
-Example Value
-
-```JSON
-{
-  "type": "string",
-  "title": "string",
-  "status": 0,
-  "detail": "string",
-  "instance": "string"
-}
-```
-
-**Response 403 - Forbidden:** <br>
-Example Value:
-
-```JSON
-{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.3","title":"Forbidden","status":403,"traceId":"00-44eab35cb9ca2049b24de316f380a774-a724e045b09dfc44-00"}
-```
-
-This error message could occur if you try to create an instance where the logged-in user does not have the necessary rights to the organisation number defined in the request header.
-This can also occur if the user does not have the correct roles necessary for creating an instance.
-
-**Response 404 - Not Found:** <br>
-Example Value:
-
-```JSON
-"Cannot lookup party: Failed to lookup party by organisationNumber: 123456789. The exception was: 404 - Not Found - "
-```
-
-This error message can occur when you set an invalid organisation number in the request header.
-
-### `PUT {instansUrl}/data/{dataId}`
-
-**Response 403 - Forbidden:** <br>
-If the logged-in user attempt to upload a file to the instance, but the person does not have the correct roles, you will get the response code 403 in return.
-
-### `POST {instansUrl}/data?dataType=mvamelding`
-
-**Response 403 - Forbidden:** <br>
-If the logged-in user attempt to upload a file to the instance, but the person does not have the correct roles, you will get the response code 403 in return.
-
-### `POST {instansUrl}/data?dataType=vedlegg`
-
-**Response 403 - Forbidden:** <br>
-If the logged-in user attempt to upload a file to the instance, but the person does not have the correct roles, you will get the response code 403 in return.
-
-### `PUT {instansUrl}/process/next`
-
-**Response 403 - Forbidden:** <br>
+_Response 403 - Forbidden:_ <br>
 If the logged-in user attempt to update to the next task in the instance process, but does not have the correct roles, you will get the response code 403 in return.
 
-**Response 409 - Conflict:** <br>
+_Response 409 - Conflict:_ <br>
 Example Value
 
 ```JSON
@@ -460,9 +458,11 @@ If the list of attachments defined in at-return submission is different from the
 
 This error message will occur if the value of the field message category in vat-return submission is different from the message category in the vat-return.
 
-### `GET {instansUrl}`
+### Retrieving the instance
 
-**Response 400 - Bad Request:** <br>
+**Error Messages**
+
+_Response 400 - Bad Request:_ <br>
 Example Value
 
 ```JSON
@@ -475,10 +475,10 @@ Example Value
 }
 ```
 
-**Response 403 - Forbidden:** <br>
+_Response 403 - Forbidden:_ <br>
 This error message will occur if the logged-in user attempt to retrieve the instance, but the person does not have the correct roles.
 
-**Response 404 - Not Found:** <br>
+_Response 404 - Not Found:_ <br>
 Example Value
 
 ```JSON


### PR DESCRIPTION
mva-melding blir vel vat-return, og MvaMeldingInnsending blir vat-return submission. 
Skal Meldingskategori bli oversatt? f.eks: message category.
Det er jo et felt i en xsd, så virka bare litt rart å oversette den. 