### PR TITLE
Removed space so that matching of merknader works properly

### DIFF
--- a/docs/documentation/informasjonsmodell/kodelister/merknad.xml
+++ b/docs/documentation/informasjonsmodell/kodelister/merknad.xml
@@ -129,7 +129,7 @@
         </beskrivelse>
     </kode>
     <kode>
-        <tekniskNavn>gjenutførsel  eller retur</tekniskNavn>
+        <tekniskNavn>gjenutførsel eller retur</tekniskNavn>
         <beskrivelse>
             <spraakTekst>
                 <tekst>Forklaring på differanse mellom rapport fra Toll (tolldeklarasjoner) og skattemelding MVA</tekst>


### PR DESCRIPTION
There was an extra space in the merknad "gjenutførsel  eller retur", so this PR fixed that.

We are using this when mapping the legal merknad to be used, so it cannot have typos. It would probably be nice to have with a test that handles this if there were new merknader added later.